### PR TITLE
Adding possibility to configure custom character replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ falseNegatives := []string{"dumbass"}
 profanityDetector := goaway.NewProfanityDetector().WithCustomDictionary(profanities, falsePositives, falseNegatives)
 ```
 
+By defailt characters `.` `_` `-` `?` `(` `)` `|` `~` are stripped from the original string. 
+
+If you want to strip additional (or different) special characters you can override it using
+```go
+goaway.NewProfanityDetector().WithIgnoredCharacters(rune[]("{}:\":<?>"))
+```
+
 
 ## In the background
 While using a giant regex query to handle everything would be a way of doing it, as more words 
@@ -83,4 +90,3 @@ In the future, the following additional steps could also be considered:
 - All words that have the same character repeated more than twice in a row are removed (e.g. `poooop -> poop`)
   - NOTE: This is obviously not a perfect approach, as words like `fuuck` wouldn't be detected, but it's better than nothing.
   - The upside of this method is that we only need to add base bad words, and not all tenses of said bad word. (e.g. the `fuck` entry would support `fucker`, `fucking`, etc.)
-  

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ falseNegatives := []string{"dumbass"}
 profanityDetector := goaway.NewProfanityDetector().WithCustomDictionary(profanities, falsePositives, falseNegatives)
 ```
 
-By defailt characters `.` `_` `-` `?` `(` `)` `|` `~` are stripped from the original string. 
+By default, the characters `.` `_` `-` `?` `(` `)` `|` `~` are stripped from the original string. 
 
 If you want to strip additional (or different) special characters you can override it using
 ```go

--- a/goaway.go
+++ b/goaway.go
@@ -86,11 +86,13 @@ func (g *ProfanityDetector) WithSanitizeSpaces(sanitize bool) *ProfanityDetector
 	return g
 }
 
+// WithSpecialCharacters allows configuring special characters that should be removed before checking for profanities
 func (g *ProfanityDetector) WithSpecialCharacters(specialCharacters []rune) *ProfanityDetector {
 	g.specialCharactersReplacementMap = createReplacementMap(specialCharacters)
 	return g
 }
 
+// WithLeetSpeakReplacements allows configuring custom leet speak replacements
 func (g *ProfanityDetector) WithLeetSpeakReplacements(replacementMap map[rune]rune) *ProfanityDetector {
 	g.leetSpeekReplacementMap = replacementMap
 	return g

--- a/goaway.go
+++ b/goaway.go
@@ -45,7 +45,7 @@ func NewProfanityDetector() *ProfanityDetector {
 		profanities:                     DefaultProfanities,
 		falsePositives:                  DefaultFalsePositives,
 		falseNegatives:                  DefaultFalseNegatives,
-		specialCharactersReplacementMap: DefaultSpecialCharacterReplacements,
+		specialCharactersReplacementMap: createIgnoreMap(DefaultIgnoredSpecialCharacters),
 		leetSpeekReplacementMap:         DefaultLeetspeekCharactersReplacement,
 	}
 }
@@ -88,7 +88,7 @@ func (g *ProfanityDetector) WithSanitizeSpaces(sanitize bool) *ProfanityDetector
 
 // WithSpecialCharacters allows configuring special characters that should be removed before checking for profanities
 func (g *ProfanityDetector) WithSpecialCharacters(specialCharacters []rune) *ProfanityDetector {
-	g.specialCharactersReplacementMap = createReplacementMap(specialCharacters)
+	g.specialCharactersReplacementMap = createIgnoreMap(specialCharacters)
 	return g
 }
 

--- a/goaway.go
+++ b/goaway.go
@@ -28,25 +28,25 @@ type ProfanityDetector struct {
 	sanitizeAccents           bool
 	sanitizeSpaces            bool
 
-	profanities                     []string
-	falseNegatives                  []string
-	falsePositives                  []string
-	specialCharactersReplacementMap map[rune]rune
-	leetSpeekReplacementMap         map[rune]rune
+	profanities              []string
+	falseNegatives           []string
+	falsePositives           []string
+	ignoredSpecialCharacters map[rune]rune
+	leetSpeekReplacementMap  map[rune]rune
 }
 
 // NewProfanityDetector creates a new ProfanityDetector
 func NewProfanityDetector() *ProfanityDetector {
 	return &ProfanityDetector{
-		sanitizeSpecialCharacters:       true,
-		sanitizeLeetSpeak:               true,
-		sanitizeAccents:                 true,
-		sanitizeSpaces:                  true,
-		profanities:                     DefaultProfanities,
-		falsePositives:                  DefaultFalsePositives,
-		falseNegatives:                  DefaultFalseNegatives,
-		specialCharactersReplacementMap: createIgnoreMap(DefaultIgnoredSpecialCharacters),
-		leetSpeekReplacementMap:         DefaultLeetspeekCharactersReplacement,
+		sanitizeSpecialCharacters: true,
+		sanitizeLeetSpeak:         true,
+		sanitizeAccents:           true,
+		sanitizeSpaces:            true,
+		profanities:               DefaultProfanities,
+		falsePositives:            DefaultFalsePositives,
+		falseNegatives:            DefaultFalseNegatives,
+		ignoredSpecialCharacters:  createIgnoreMap(DefaultIgnoredCharacters),
+		leetSpeekReplacementMap:   DefaultLeetspeekCharactersReplacement,
 	}
 }
 
@@ -86,9 +86,9 @@ func (g *ProfanityDetector) WithSanitizeSpaces(sanitize bool) *ProfanityDetector
 	return g
 }
 
-// WithSpecialCharacters allows configuring special characters that should be removed before checking for profanities
-func (g *ProfanityDetector) WithSpecialCharacters(specialCharacters []rune) *ProfanityDetector {
-	g.specialCharactersReplacementMap = createIgnoreMap(specialCharacters)
+// WithIgnoredCharacters allows configuring special characters that should be removed before checking for profanities
+func (g *ProfanityDetector) WithIgnoredCharacters(ignoredCharacters []rune) *ProfanityDetector {
+	g.ignoredSpecialCharacters = createIgnoreMap(ignoredCharacters)
 	return g
 }
 
@@ -186,7 +186,7 @@ func (g ProfanityDetector) sanitize(s string, rememberOriginalIndexes bool) (str
 		replaced := false
 		if g.sanitizeLeetSpeak {
 
-			_, isSpecialCharacter := g.specialCharactersReplacementMap[char]
+			_, isSpecialCharacter := g.ignoredSpecialCharacters[char]
 			if !isSpecialCharacter || g.sanitizeSpecialCharacters {
 				repl, found := g.leetSpeekReplacementMap[char]
 				if found {
@@ -197,7 +197,7 @@ func (g ProfanityDetector) sanitize(s string, rememberOriginalIndexes bool) (str
 		}
 		if g.sanitizeSpecialCharacters {
 			if !replaced {
-				repl, found := g.specialCharactersReplacementMap[char]
+				repl, found := g.ignoredSpecialCharacters[char]
 				if found {
 					sb.WriteRune(repl)
 					replaced = true

--- a/goaway_test.go
+++ b/goaway_test.go
@@ -260,13 +260,13 @@ func TestBadWordsWithSpecialCharacters(t *testing.T) {
 		},
 		{
 			name:              "With empty special character mapping",
-			profanityDetector: NewProfanityDetector().WithSpecialCharacters([]rune("")),
+			profanityDetector: NewProfanityDetector().WithIgnoredCharacters([]rune("")),
 			sentence:          "f.u.c.k",
 			result:            false,
 		},
 		{
 			name:              "With custom special character mapping",
-			profanityDetector: NewProfanityDetector().WithSpecialCharacters([]rune(".")),
+			profanityDetector: NewProfanityDetector().WithIgnoredCharacters([]rune(".")),
 			sentence:          "f.u.c.k",
 			result:            true,
 		},

--- a/goaway_test.go
+++ b/goaway_test.go
@@ -100,6 +100,10 @@ func TestProfanityDetector_Censor(t *testing.T) {
 			expectedCensoredOutput: "But the table is on ****ing fire",
 		},
 		{
+			input:                  "f.u_ck this s.h-i~t",
+			expectedCensoredOutput: "*.*_** this *.*-*~*",
+		},
+		{
 			input:                  "glass",
 			expectedCensoredOutput: "glass",
 		},
@@ -236,6 +240,78 @@ func TestSentencesWithBadWords(t *testing.T) {
 				if !tt.profanityDetector.IsProfane(s) {
 					t.Error("Expected true, got false from sentence", s)
 				}
+			}
+		})
+	}
+}
+
+func TestBadWordsWithSpecialCharacters(t *testing.T) {
+	tests := []struct {
+		name              string
+		profanityDetector *ProfanityDetector
+		sentence          string
+		result            bool
+	}{
+		{
+			name:              "With default special character mapping",
+			profanityDetector: NewProfanityDetector(),
+			sentence:          "f.u.c.k",
+			result:            true,
+		},
+		{
+			name:              "With empty special character mapping",
+			profanityDetector: NewProfanityDetector().WithSpecialCharacters([]rune("")),
+			sentence:          "f.u.c.k",
+			result:            false,
+		},
+		{
+			name:              "With custom special character mapping",
+			profanityDetector: NewProfanityDetector().WithSpecialCharacters([]rune(".")),
+			sentence:          "f.u.c.k",
+			result:            true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.profanityDetector.IsProfane(tt.sentence)
+			if got != tt.result {
+				t.Errorf("Expected %v, got %v from sentence %s", tt.result, got, tt.sentence)
+			}
+		})
+	}
+}
+
+func TestCustomLeetspeakMapping(t *testing.T) {
+	tests := []struct {
+		name              string
+		profanityDetector *ProfanityDetector
+		sentence          string
+		result            bool
+	}{
+		{
+			name:              "With default leet speak character mapping",
+			profanityDetector: NewProfanityDetector(),
+			sentence:          "5#1+",
+			result:            true,
+		},
+		{
+			name:              "With custom special character mapping",
+			profanityDetector: NewProfanityDetector().WithLeetSpeakReplacements(map[rune]rune{'(': 'c'}),
+			sentence:          "fu(k",
+			result:            true,
+		},
+		{
+			name:              "With empt special character mapping",
+			profanityDetector: NewProfanityDetector().WithLeetSpeakReplacements(map[rune]rune{}),
+			sentence:          "5#1+",
+			result:            false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.profanityDetector.IsProfane(tt.sentence)
+			if got != tt.result {
+				t.Errorf("Expected %v, got %v from sentence %s", tt.result, got, tt.sentence)
 			}
 		})
 	}

--- a/specialcharacters.go
+++ b/specialcharacters.go
@@ -10,8 +10,10 @@ func createReplacementMap(runes []rune) map[rune]rune {
 	return specialReplacementMap
 }
 
+// DefaultLeetspeekCharactersReplacement contains list of special character runes that will be turned to special character mapping
 var DefaultSpecialCharacterReplacements = createReplacementMap(DefaultSpecialCharacters)
 
+// DefaultLeetspeekCharactersReplacement contains mapping for leet speak characters mapping. Note that special characters will not be mapped if sanitizeSpecialCharacters is set to false
 var DefaultLeetspeekCharactersReplacement = map[rune]rune{
 	'4': 'a',
 	'$': 's',

--- a/specialcharacters.go
+++ b/specialcharacters.go
@@ -1,0 +1,27 @@
+package goaway
+
+var DefaultSpecialCharacters = []rune("._-?()|~")
+
+func createReplacementMap(runes []rune) map[rune]rune {
+	specialReplacementMap := make(map[rune]rune, len(runes))
+	for _, character := range runes {
+		specialReplacementMap[character] = ' '
+	}
+	return specialReplacementMap
+}
+
+var DefaultSpecialCharacterReplacements = createReplacementMap(DefaultSpecialCharacters)
+
+var DefaultLeetspeekCharactersReplacement = map[rune]rune{
+	'4': 'a',
+	'$': 's',
+	'!': 'i',
+	'+': 't',
+	'#': 'h',
+	'@': 'a',
+	'0': 'o',
+	'1': 'i',
+	'7': 'l',
+	'3': 'e',
+	'5': 's',
+}

--- a/specialcharacters.go
+++ b/specialcharacters.go
@@ -1,8 +1,8 @@
 package goaway
 
-var DefaultSpecialCharacters = []rune("._-?()|~")
+var DefaultIgnoredSpecialCharacters = []rune("._-?()|~")
 
-func createReplacementMap(runes []rune) map[rune]rune {
+func createIgnoreMap(runes []rune) map[rune]rune {
 	specialReplacementMap := make(map[rune]rune, len(runes))
 	for _, character := range runes {
 		specialReplacementMap[character] = ' '
@@ -10,10 +10,7 @@ func createReplacementMap(runes []rune) map[rune]rune {
 	return specialReplacementMap
 }
 
-// DefaultLeetspeekCharactersReplacement contains list of special character runes that will be turned to special character mapping
-var DefaultSpecialCharacterReplacements = createReplacementMap(DefaultSpecialCharacters)
-
-// DefaultLeetspeekCharactersReplacement contains mapping for leet speak characters mapping. Note that special characters will not be mapped if sanitizeSpecialCharacters is set to false
+// DefaultLeetspeekCharactersReplacement contains mapping for leet speak characters. Note that special leet speak characters will not be mapped if sanitizeSpecialCharacters is set to false
 var DefaultLeetspeekCharactersReplacement = map[rune]rune{
 	'4': 'a',
 	'$': 's',

--- a/specialcharacters.go
+++ b/specialcharacters.go
@@ -1,6 +1,6 @@
 package goaway
 
-var DefaultIgnoredSpecialCharacters = []rune("._-?()|~")
+var DefaultIgnoredCharacters = []rune("._-?()|~")
 
 func createIgnoreMap(runes []rune) map[rune]rune {
 	specialReplacementMap := make(map[rune]rune, len(runes))


### PR DESCRIPTION
I added the ability to configure the special characters to be replaced. I also changed the implementation to be a loop over the string. Let me know if you disagree with this. 

The mapping could also be implemented as `map[string]string` however this would complicate things with remembering the indexes. Currently there is only the case of `()` that has special handling.