### PR TITLE
fix(): Changing the way we get the index to runes for censoring

### DIFF
--- a/goaway.go
+++ b/goaway.go
@@ -149,26 +149,6 @@ func (g *ProfanityDetector) indexToRune(s string, index int) int {
 	return -1
 }
 
-func (g *ProfanityDetector) takeRunesFromIndex(s string, index int) string {
-	ret := make([]rune, 0)
-	for i, i2 := range []rune(s) {
-		if i >= index {
-			ret = append(ret, i2)
-		}
-	}
-	return string(ret)
-}
-
-func (g *ProfanityDetector) takeRunesToIndex(s string, index int) string {
-	ret := make([]rune, 0)
-	for i, i2 := range []rune(s) {
-		if i < index {
-			ret = append(ret, i2)
-		}
-	}
-	return string(ret)
-}
-
 // Censor takes in a string (word or sentence) and tries to censor all profanities found.
 func (g *ProfanityDetector) Censor(s string) string {
 	censored := []rune(s)

--- a/goaway.go
+++ b/goaway.go
@@ -171,7 +171,7 @@ func (g *ProfanityDetector) takeRunesToIndex(s string, index int) string {
 
 // Censor takes in a string (word or sentence) and tries to censor all profanities found.
 func (g *ProfanityDetector) Censor(s string) string {
-	censored := s
+	censored := []rune(s)
 	var originalIndexes []int
 	s, originalIndexes = g.sanitize(s, true)
 	// Check for false negatives
@@ -180,10 +180,8 @@ func (g *ProfanityDetector) Censor(s string) string {
 		for currentIndex != -1 {
 			if foundIndex := strings.Index(s[currentIndex:], word); foundIndex != -1 {
 				for i := 0; i < len([]rune(word)); i++ {
-					runeIndex := g.indexToRune(censored, currentIndex+foundIndex+i)
-					prefix := g.takeRunesToIndex(censored, originalIndexes[runeIndex])
-					postfix := g.takeRunesFromIndex(censored, originalIndexes[runeIndex]+1)
-					censored = prefix + "*" + postfix
+					runeIndex := g.indexToRune(string(censored), currentIndex+foundIndex+i)
+					censored[originalIndexes[runeIndex]] = '*'
 				}
 				currentIndex += foundIndex + len([]rune(word))
 			} else {
@@ -211,10 +209,8 @@ func (g *ProfanityDetector) Censor(s string) string {
 		for currentIndex != -1 {
 			if foundIndex := strings.Index(s[currentIndex:], word); foundIndex != -1 {
 				for i := 0; i < len([]rune(word)); i++ {
-					runeIndex := g.indexToRune(censored, currentIndex+foundIndex+i)
-					prefix := g.takeRunesToIndex(censored, originalIndexes[runeIndex])
-					postfix := g.takeRunesFromIndex(censored, originalIndexes[runeIndex]+1)
-					censored = prefix + "*" + postfix
+					runeIndex := g.indexToRune(string(censored), currentIndex+foundIndex+i)
+					censored[originalIndexes[runeIndex]] = '*'
 				}
 				currentIndex += foundIndex + len([]rune(word))
 			} else {
@@ -222,7 +218,7 @@ func (g *ProfanityDetector) Censor(s string) string {
 			}
 		}
 	}
-	return censored
+	return string(censored)
 }
 
 func (g ProfanityDetector) sanitize(s string, rememberOriginalIndexes bool) (string, []int) {

--- a/goaway_test.go
+++ b/goaway_test.go
@@ -100,6 +100,10 @@ func TestProfanityDetector_Censor(t *testing.T) {
 			expectedCensoredOutput: "But the table is on ****ing fire",
 		},
 		{
+			input:                  "““““““““““““But the table is on fucking fire“",
+			expectedCensoredOutput: "““““““““““““But the table is on ****ing fire“",
+		},
+		{
 			input:                  "f.u_ck this s.h-i~t",
 			expectedCensoredOutput: "*.*_** this *.*-*~*",
 		},


### PR DESCRIPTION
This fixes #25 

Root cause of this issue is that `strings.Index` returns byte index. So I switched the calculation of the indexes to use rune index as well as taking the string up to specified index and from specified index. Mabye the censored string could be changed to `[]rune` and instead of calling `takeRunesFromIndex` we could just update the `censored` inplace. 