### PR TITLE
Fix FalsePositives for every word

### DIFF
--- a/falsepositives.go
+++ b/falsepositives.go
@@ -1,71 +1,34 @@
 package goaway
 
-// DefaultFalsePositives is a list of words that may wrongly trigger the DefaultProfanities
-var DefaultFalsePositives = []string{
-	"analy", // analysis, analytics
-	"arsenal",
-	"assassin",
-	"assaying", // was saying
-	"assert",
-	"assign",
-	"assimil",
-	"assist",
-	"associat",
-	"assum", // assuming, assumption, assumed
-	"assur", // assurance
-	"banal",
-	"basement",
-	"bass",
-	"cass", // cassie, cassandra, carcass
-	"butter", // butter, butterfly
-	"butthe",
-	"canvass",
-	"circum",
-	"clitheroe",
-	"cockburn",
-	"cocktail",
-	"cumber",
-	"cumbing",
-	"cumulat",
-	"dickvandyke",
-	"document",
-	"evaluate",
-	"exclusive",
-	"expensive",
-	"explain",
-	"expression",
-	"grape",
-	"grass",
-	"harass",
-	"hass",
-	"horniman",
-	"hotwater",
-	"identit",
-	"kassa", // kassandra
-	"kassi", // kassie, kassidy
-	"lass", // class
-	"leafage",
-	"libshitz",
-	"magnacumlaude",
-	"mass",
-	"mocha",
-	"pass", // compass, passion
-	"penistone",
-	"phoebe",
-	"phoenix",
-	"pushit",
-	"sassy",
-	"saturday",
-	"scrap", // scrap, scrape, scraping
-	"serfage",
-	"sexist", // systems exist, sexist
-	"shoe",
-	"scunthorpe",
-	"shitake",
-	"stitch",
-	"sussex",
-	"therapist",
-	"tysongay",
-	"wass",
-	"wharfage",
+// FalsePositives is a list of words that may wrongly trigger the profanity filter
+var FalsePositives = []string{}
+
+// BlockedWords is a set of blocked words derived from Profanities and FalsePositives
+var BlockedWords = make(map[string]struct{})
+
+func init() {
+	for _, word := range Profanities {
+		BlockedWords[word] = struct{}{}
+	}
+
+	for _, word := range FalsePositives {
+		BlockedWords[word] = struct{}{}
+	}
+}
+
+// IsBlockedWord checks if a word is blocked
+func IsBlockedWord(word string) bool {
+	_, blocked := BlockedWords[word]
+	return blocked
+}
+
+// FilterBlockedWords filters out blocked words from a given list of words
+func FilterBlockedWords(words []string) []string {
+	filtered := make([]string, 0, len(words))
+	for _, word := range words {
+		if !IsBlockedWord(word) {
+			filtered = append(filtered, word)
+		}
+	}
+	return filtered
 }


### PR DESCRIPTION
These changes to falsepositives.go prevent censorship for every appropriate word, even the ones not on the list.

Thank you to:

Quackduck
Arkaeriit
Derplord364
