### PR TITLE
fix(panic): fix panic when censoring utf-8

### DIFF
--- a/goaway_test.go
+++ b/goaway_test.go
@@ -655,3 +655,24 @@ func TestSanitizeWithoutSanitizingLeetSpeak(t *testing.T) {
 		t.Errorf("Expected '%s', got '%s'", expectedString, sanitizedString)
 	}
 }
+
+func TestDefaultDriver_UTF8(t *testing.T) {
+	detector := NewProfanityDetector().WithCustomDictionary(
+		[]string{"anal", "あほ"}, // profanities
+		[]string{"あほほ"},        // falsePositives
+		[]string{"あほほし"},       // falseNegatives
+	)
+
+	unsanitizedString := "いい加減にしろ あほほし あほほ あほ anal ほ"
+	expectedString := "いい加減にしろ **** あほほ ** **** ほ"
+
+	isProfane := detector.IsProfane(unsanitizedString)
+	if !isProfane {
+		t.Error("Expected false, got false from sentence", unsanitizedString)
+	}
+
+	sanitizedString := detector.Censor(unsanitizedString)
+	if sanitizedString != expectedString {
+		t.Errorf("Expected '%s', got '%s'", expectedString, sanitizedString)
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
https://github.com/TwiN/go-away/issues/43

Modified indexToRune to correctly count runes up to the given byte index. Adjusted Censor function to handle multi-byte characters properly, ensuring accurate index calculations during the censoring process. Updated incrementation of currentIndex to consider byte length, facilitating correct string iteration.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
