### PR TITLE
fix(panic): fix panic when censoring utf-8

### DIFF
--- a/goaway.go
+++ b/goaway.go
@@ -152,55 +152,54 @@ func (g *ProfanityDetector) indexToRune(s string, index int) int {
 	return count
 }
 
-// Censor takes in a string (word or sentence) and tries to censor all profanities found.
 func (g *ProfanityDetector) Censor(s string) string {
 	censored := []rune(s)
 	var originalIndexes []int
 	s, originalIndexes = g.sanitize(s, true)
 	runeWordLength := 0
 
-	checkProfanity := func(wordList []string) {
-		for _, word := range wordList {
-			currentIndex := 0
-			runeWordLength = len([]rune(word))
-			for currentIndex != -1 {
-				if foundIndex := strings.Index(s[currentIndex:], word); foundIndex != -1 {
-					for i := 0; i < runeWordLength; i++ {
-						runeIndex := g.indexToRune(s, currentIndex+foundIndex) + i
-						if runeIndex < len(originalIndexes) {
-							censored[originalIndexes[runeIndex]] = '*'
-						}
-					}
-					currentIndex += foundIndex + len([]byte(word))
-				} else {
-					break
-				}
-			}
-		}
-	}
-
-	removeFalsePositives := func() {
-		for _, word := range g.falsePositives {
-			currentIndex := 0
-			runeWordLength = len([]rune(word))
-			for currentIndex != -1 {
-				if foundIndex := strings.Index(s[currentIndex:], word); foundIndex != -1 {
-					foundRuneIndex := g.indexToRune(s, foundIndex)
-					originalIndexes = append(originalIndexes[:foundRuneIndex], originalIndexes[foundRuneIndex+runeWordLength:]...)
-					currentIndex += foundIndex + len([]byte(word))
-				} else {
-					break
-				}
-			}
-			s = strings.Replace(s, word, "", -1)
-		}
-	}
-
-	checkProfanity(g.falseNegatives)
-	removeFalsePositives()
-	checkProfanity(g.profanities)
+	g.checkProfanity(&s, &originalIndexes, &censored, g.falseNegatives, &runeWordLength)
+	g.removeFalsePositives(&s, &originalIndexes, &runeWordLength)
+	g.checkProfanity(&s, &originalIndexes, &censored, g.profanities, &runeWordLength)
 
 	return string(censored)
+}
+
+func (g *ProfanityDetector) checkProfanity(s *string, originalIndexes *[]int, censored *[]rune, wordList []string, runeWordLength *int) {
+	for _, word := range wordList {
+		currentIndex := 0
+		*runeWordLength = len([]rune(word))
+		for currentIndex != -1 {
+			if foundIndex := strings.Index((*s)[currentIndex:], word); foundIndex != -1 {
+				for i := 0; i < *runeWordLength; i++ {
+					runeIndex := g.indexToRune(*s, currentIndex+foundIndex) + i
+					if runeIndex < len(*originalIndexes) {
+						(*censored)[(*originalIndexes)[runeIndex]] = '*'
+					}
+				}
+				currentIndex += foundIndex + len([]byte(word))
+			} else {
+				break
+			}
+		}
+	}
+}
+
+func (g *ProfanityDetector) removeFalsePositives(s *string, originalIndexes *[]int, runeWordLength *int) {
+	for _, word := range g.falsePositives {
+		currentIndex := 0
+		*runeWordLength = len([]rune(word))
+		for currentIndex != -1 {
+			if foundIndex := strings.Index((*s)[currentIndex:], word); foundIndex != -1 {
+				foundRuneIndex := g.indexToRune(*s, foundIndex)
+				*originalIndexes = append((*originalIndexes)[:foundRuneIndex], (*originalIndexes)[foundRuneIndex+*runeWordLength:]...)
+				currentIndex += foundIndex + len([]byte(word))
+			} else {
+				break
+			}
+		}
+		*s = strings.Replace(*s, word, "", -1)
+	}
 }
 
 func (g ProfanityDetector) sanitize(s string, rememberOriginalIndexes bool) (string, []int) {

--- a/goaway_test.go
+++ b/goaway_test.go
@@ -655,3 +655,24 @@ func TestSanitizeWithoutSanitizingLeetSpeak(t *testing.T) {
 		t.Errorf("Expected '%s', got '%s'", expectedString, sanitizedString)
 	}
 }
+
+func TestDefaultDriver_UTF8(t *testing.T) {
+	detector := NewProfanityDetector().WithCustomDictionary(
+		[]string{"anal", "あほ"}, // profanities
+		[]string{"あほほ"},        // falsePositives
+		[]string{"あほほし"},       // falseNegatives
+	)
+
+	unsanitizedString := "いい加減にしろ あほほし あほほ あほ anal ほ"
+	expectedString := "いい加減にしろ **** あほほ ** **** ほ"
+
+	isProfane := detector.IsProfane(unsanitizedString)
+	if !isProfane {
+		t.Error("Expected false, got false from sentence", unsanitizedString)
+	}
+
+	sanitizedString := detector.Censor(unsanitizedString)
+	if sanitizedString != expectedString {
+		t.Errorf("Expected '%s', got '%s'", expectedString, sanitizedString)
+	}
+}


### PR DESCRIPTION
Summary
https://github.com/TwiN/go-away/issues/43

Modified indexToRune to correctly count runes up to the given byte index. Adjusted Censor function to handle multi-byte characters properly, ensuring accurate index calculations during the censoring process. Updated incrementation of currentIndex to consider byte length, facilitating correct string iteration.

Checklist
 Tested and/or added tests to validate that the changes work as intended, if applicable.
 Updated documentation in README.md, if applicable.