### PR TITLE
fix: add "button" to false positives

### DIFF
--- a/falsepositives.go
+++ b/falsepositives.go
@@ -19,6 +19,7 @@ var DefaultFalsePositives = []string{
 	"cass",   // cassie, cassandra, carcass
 	"butter", // butter, butterfly
 	"butthe",
+	"button",
 	"canvass",
 	"circum",
 	"clitheroe",

--- a/goaway_test.go
+++ b/goaway_test.go
@@ -517,7 +517,7 @@ func TestFalsePositives(t *testing.T) {
 		"systems exist",               // systemS EXist
 		"saturday",                    // saTURDay
 		"therapeutic",
-		"button",
+		"press the button",
 	}
 	tests := []struct {
 		name              string

--- a/goaway_test.go
+++ b/goaway_test.go
@@ -517,6 +517,7 @@ func TestFalsePositives(t *testing.T) {
 		"systems exist",               // systemS EXist
 		"saturday",                    // saTURDay
 		"therapeutic",
+		"button",
 	}
 	tests := []struct {
 		name              string


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
When censoring the string "button", the profanity detector censors a substring which results in "****on".

Fixes #69 


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
