### PR TITLE
fix: data race in remove accents

### DIFF
--- a/goaway.go
+++ b/goaway.go
@@ -17,7 +17,6 @@ const (
 
 var (
 	defaultProfanityDetector *ProfanityDetector
-	removeAccentsTransformer transform.Transformer
 )
 
 // ProfanityDetector contains the dictionaries as well as the configuration
@@ -244,9 +243,7 @@ func (g ProfanityDetector) sanitize(s string, rememberOriginalIndexes bool) (str
 // removeAccents strips all accents from characters.
 // Only called if ProfanityDetector.removeAccents is set to true
 func removeAccents(s string) string {
-	if removeAccentsTransformer == nil {
-		removeAccentsTransformer = transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
-	}
+	removeAccentsTransformer := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
 	for _, character := range s {
 		// If there's a character outside the range of supported runes, there might be some accented words
 		if character < firstRuneSupported || character > lastRuneSupported {

--- a/goaway_bench_test.go
+++ b/goaway_bench_test.go
@@ -135,3 +135,12 @@ func BenchmarkIsProfaneConcurrently(b *testing.B) {
 	})
 	b.ReportAllocs()
 }
+
+func BenchmarkIsProfaneConcurrently_WithAccents(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			IsProfane("ÄšŚ")
+		}
+	})
+	b.ReportAllocs()
+}


### PR DESCRIPTION
This PR fixes a data race associated with reuse of `removeAccentsTransformer` - when IsProfane() or other methods are called from multiple goroutines (ex. in a HTTP Server handler), sanitization fails with `slice bounds out of range` errors.

The issue is fixed by using a new instance of `removeAccentsTransformer` for every call to `removeAccents`. 

To reproduce, run the newly added `BenchmarkIsProfaneConcurrently_WithAccents` with
```
go test -race -benchmem -bench ^BenchmarkIsProfaneConcurrently_WithAccents$
```
(note - it will pass on the last commit of this branch that contains a fix). 
## Summary
Fix a data race in `removeAccents`, making `ProfanityDetector` safe for use from multiple goroutines.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
