### PR TITLE
fix: Add `gyat` to DefaultProfanities

### DIFF
--- a/falsenegatives.go
+++ b/falsenegatives.go
@@ -4,7 +4,7 @@ package goaway
 //
 // This is reserved for words that may be incorrectly filtered as false positives.
 //
-// Alternatively, words that are long, or that should mark a string as profane no what the context is
+// Alternatively, words that are long, or that should mark a string as profane no matter what the context is
 // or whether the word is part of another word can also be included.
 //
 // Note that there is a test that prevents words from being in both DefaultProfanities and DefaultFalseNegatives,

--- a/goaway_test.go
+++ b/goaway_test.go
@@ -150,6 +150,11 @@ func TestProfanityDetector_Censor(t *testing.T) {
 			expectedOutput:                         "document **** document ****",
 			expectedOutputWithoutSpaceSanitization: "document **** document ****",
 		},
+		{
+			input:                                  "Everyone was staring, and someone muttered ‘gyat’ under their breath.",
+			expectedOutput:                         "Everyone was staring, and someone muttered ‘****’ under their breath.",
+			expectedOutputWithoutSpaceSanitization: "Everyone was staring, and someone muttered ‘****’ under their breath.",
+		},
 	}
 	for _, tt := range tests {
 		t.Run("default_"+tt.input, func(t *testing.T) {

--- a/profanities.go
+++ b/profanities.go
@@ -86,4 +86,5 @@ var DefaultProfanities = []string{
 	"vagina",
 	"wank",
 	"whore",
+	"gyat",
 }

--- a/profanities.go
+++ b/profanities.go
@@ -41,6 +41,7 @@ var DefaultProfanities = []string{
 	"fudgepacker",
 	"flange",
 	"gtfo",
+	"gyat",
 	"hoe", // while that's also a tool, I doubt somebody would be checking for profanities if that tool was relevant
 	"horny",
 	"incest",
@@ -86,5 +87,4 @@ var DefaultProfanities = []string{
 	"vagina",
 	"wank",
 	"whore",
-	"gyat",
 }


### PR DESCRIPTION
## Summary
- Added a new word to `DefaultProfanities` to improve profanity detection.
- Implemented a test case to validate the addition of the new word.
- Updated `falsenegatives.go` to include the missing word.

<details>
  <summary>Word</summary>

-   gyat

</details>

## Checklist
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ - ] Updated documentation in `README.md`, if applicable (ensure any new functionality or word lists are described).