### PR TITLE
feat: implement WithExactWord to allow stricter matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ You can also disable the default behavior of white space sanitization like so:
 profanityDetector := goaway.NewProfanityDetector().WithSanitizeSpaces(false)
 profanityDetector.IsProfane("sh it") // returns false because we're not sanitizing white spaces
 ```
+You can also require stricter matching by enabling `WithExactWord`:
+```go
+profanityDetector := NewProfanityDetector().WithExactWord(true).WithSanitizeSpecialCharacters(true)
+profanityDetector.IsProfane("analyst") // returns false because we match the exact word
+profanityDetector.IsProfane("anal") // returns true
+```
 
 By default, the `NewProfanityDetector` constructor uses the default dictionaries for profanities, false positives and false negatives.
 These dictionaries are exposed as `goaway.DefaultProfanities`, `goaway.DefaultFalsePositives` and `goaway.DefaultFalseNegatives` respectively.

--- a/goaway.go
+++ b/goaway.go
@@ -143,18 +143,18 @@ func (g *ProfanityDetector) ExtractProfanity(s string) string {
 		s = strings.Replace(s, word, "", -1)
 	}
 
-	if !g.exactWord {
-		// Check for profanities
-		for _, word := range g.profanities {
-			if match := strings.Contains(s, word); match {
-				return word
-			}
-		}
-	} else {
+	if g.exactWord {
 		tokens := strings.Split(s, space)
 		for _, token := range tokens {
 			if sliceContains(g.profanities, token) {
 				return token
+			}
+		}
+	} else {
+		// Check for profanities
+		for _, word := range g.profanities {
+			if match := strings.Contains(s, word); match {
+				return word
 			}
 		}
 	}

--- a/goaway_test.go
+++ b/goaway_test.go
@@ -548,6 +548,30 @@ func TestFalsePositives(t *testing.T) {
 	}
 }
 
+func TestExactWord(t *testing.T) {
+	sentences := []string{
+		"I'm an analyst",
+	}
+	tests := []struct {
+		name              string
+		profanityDetector *ProfanityDetector
+	}{
+		{
+			name:              "With Empty FalsePositives",
+			profanityDetector: NewProfanityDetector().WithExactWord(true).WithCustomDictionary(DefaultProfanities, nil, nil),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, s := range sentences {
+				if tt.profanityDetector.IsProfane(s) {
+					t.Error("Expected false, got true from:", s)
+				}
+			}
+		})
+	}
+}
+
 func TestFalseNegatives(t *testing.T) {
 	sentences := []string{
 		"dumb ass", // ass -> bASS (FP) -> dumBASS (FFP)
@@ -559,6 +583,10 @@ func TestFalseNegatives(t *testing.T) {
 		{
 			name:              "With Default Dictionary",
 			profanityDetector: NewProfanityDetector(),
+		},
+		{
+			name:              "With Custom Dictionary",
+			profanityDetector: NewProfanityDetector().WithCustomDictionary(DefaultProfanities, DefaultFalsePositives, DefaultFalseNegatives),
 		},
 		{
 			name:              "With Custom Dictionary",

--- a/goaway_test.go
+++ b/goaway_test.go
@@ -549,23 +549,29 @@ func TestFalsePositives(t *testing.T) {
 }
 
 func TestExactWord(t *testing.T) {
-	sentences := []string{
+	accept_sentences := []string{
 		"I'm an analyst",
 	}
+	reject_sentences := []string{"Go away, ass."}
 	tests := []struct {
 		name              string
 		profanityDetector *ProfanityDetector
 	}{
 		{
 			name:              "With Empty FalsePositives",
-			profanityDetector: NewProfanityDetector().WithExactWord(true).WithCustomDictionary(DefaultProfanities, nil, nil),
+			profanityDetector: NewProfanityDetector().WithExactWord(true).WithSanitizeSpecialCharacters(true).WithCustomDictionary(DefaultProfanities, nil, nil),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for _, s := range sentences {
+			for _, s := range accept_sentences {
 				if tt.profanityDetector.IsProfane(s) {
 					t.Error("Expected false, got true from:", s)
+				}
+			}
+			for _, s := range reject_sentences {
+				if !tt.profanityDetector.IsProfane(s) {
+					t.Error("Expected true, got false from:", s)
 				}
 			}
 		})

--- a/goaway_test.go
+++ b/goaway_test.go
@@ -549,10 +549,10 @@ func TestFalsePositives(t *testing.T) {
 }
 
 func TestExactWord(t *testing.T) {
-	accept_sentences := []string{
+	acceptSentences := []string{
 		"I'm an analyst",
 	}
-	reject_sentences := []string{"Go away, ass."}
+	rejectSentences := []string{"Go away, ass."}
 	tests := []struct {
 		name              string
 		profanityDetector *ProfanityDetector
@@ -564,12 +564,12 @@ func TestExactWord(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for _, s := range accept_sentences {
+			for _, s := range acceptSentences {
 				if tt.profanityDetector.IsProfane(s) {
 					t.Error("Expected false, got true from:", s)
 				}
 			}
-			for _, s := range reject_sentences {
+			for _, s := range rejectSentences {
 				if !tt.profanityDetector.IsProfane(s) {
 					t.Error("Expected true, got false from:", s)
 				}
@@ -596,7 +596,7 @@ func TestFalseNegatives(t *testing.T) {
 		},
 		{
 			name:              "With Custom Dictionary",
-			profanityDetector: NewProfanityDetector().WithCustomDictionary(DefaultProfanities, DefaultFalsePositives, DefaultFalseNegatives),
+			profanityDetector: NewProfanityDetector().WithExactWord(true).WithCustomDictionary(DefaultProfanities, DefaultFalsePositives, DefaultFalseNegatives),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION


## Summary

This is a fix for #38 to filter only exact words.

I chose to implement it by having an alternate implementation *only* for the profanities list, where the rest is untouched so false positives and false negatives will remain working as expected; it seems right to me that a false negative should not change from exact word matches.

I have one test in here. I could see a use for more, but  comments/feedback in that area would be appreciated so I can calibrate what sort of test coverage you're aiming for.


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
