### PR TITLE
feat: Support Writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ func main() {
     goaway.IsProfane("hello, world!")                 // returns false
     goaway.ExtractProfanity("hello, world!")          // returns ""
     goaway.Censor("hello, world!")                    // returns "hello, world!"
+
+    buf := &bytes.Buffer{}
+    detector := goaway.NewProfanityDetector()
+    writer := goaway.NewWriter(buf, detector)
+    writer.Write([]byte("fuck this shit"))
+    writer.Flush()
+    print(buf.String())                               // returns "**** this ****"  
 }
 ```
 

--- a/writer.go
+++ b/writer.go
@@ -1,0 +1,45 @@
+package goaway
+
+import "io"
+
+func NewWriter(base io.Writer, detector *ProfanityDetector) *Writer {
+	return &Writer{
+		base:     base,
+		detector: detector,
+	}
+}
+
+type Writer struct {
+	base     io.Writer
+	detector *ProfanityDetector
+	buf      []byte
+}
+
+func (w *Writer) Write(payload []byte) (int, error) {
+	last := 0
+	for i, char := range payload {
+		if char != byte('\n') {
+			continue
+		}
+
+		result := append(w.buf, payload[last:i+1]...)
+		_, err := w.base.Write([]byte(w.detector.Censor(string(result))))
+		if err != nil {
+			return 0, err
+		}
+
+		w.buf = w.buf[:0]
+		last = i + 1
+	}
+	w.buf = payload[last:]
+	return len(payload), nil
+}
+
+func (w *Writer) Flush() error {
+	if len(w.buf) == 0 {
+		return nil
+	}
+	_, err := w.base.Write([]byte(w.detector.Censor(string(w.buf))))
+	w.buf = w.buf[:0]
+	return err
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,0 +1,79 @@
+package goaway_test
+
+import (
+	"bytes"
+	"testing"
+
+	goaway "github.com/TwiN/go-away"
+)
+
+func TestWriter(t *testing.T) {
+	tests := map[string]struct {
+		input          [][]byte
+		detector       *goaway.ProfanityDetector
+		expectedOutput string
+	}{
+		"no writing, empty output": {
+			input:          [][]byte{},
+			detector:       goaway.NewProfanityDetector(),
+			expectedOutput: "",
+		},
+		"single uncensored write": {
+			input: [][]byte{
+				[]byte("I'm just a normal line"),
+			},
+			detector:       goaway.NewProfanityDetector(),
+			expectedOutput: "I'm just a normal line",
+		},
+		"single censored write": {
+			input: [][]byte{
+				[]byte("I'm just a shitty line"),
+			},
+			detector:       goaway.NewProfanityDetector(),
+			expectedOutput: "I'm just a ****ty line",
+		},
+		"multi-line single write": {
+			input: [][]byte{
+				[]byte("I'm just a shitty line\nAnd I'm another line"),
+			},
+			detector:       goaway.NewProfanityDetector(),
+			expectedOutput: "I'm just a ****ty line\nAnd I'm another line",
+		},
+		"single-line multi writes": {
+			input: [][]byte{
+				[]byte("I'm just a shitty line\n"),
+				[]byte("And I'm another line"),
+				[]byte("\nAnd I'm the final fucking line"),
+			},
+			detector:       goaway.NewProfanityDetector(),
+			expectedOutput: "I'm just a ****ty line\nAnd I'm another line\nAnd I'm the final ****ing line",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			writer := goaway.NewWriter(buf, tc.detector)
+			for _, write := range tc.input {
+				n, err := writer.Write(write)
+				if n != len(write) {
+					t.Errorf("unexpected write count %d != %d", n, len(write))
+				}
+
+				if err != nil {
+					t.Errorf("unexpected writing error %v", err)
+				}
+			}
+
+			err := writer.Flush()
+			if err != nil {
+				t.Errorf("unexpected error flushing writer %v", err)
+			}
+
+			result := buf.String()
+			if tc.expectedOutput != result {
+				t.Errorf("expected %q but recieved %q", tc.expectedOutput, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

Adds a new struct that implements the `io.Writer` interface.

I had to make a judgement call to buffer the writer input to only write when it sees line breaks to allow for all the different opportunities to censor words to take place. I'm not exactly happy with this decision, and am open to suggestions on better ways to buffer the input such that the buffer size is minimized

Relevant issue: #123 


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
