### PR TITLE
fix: treat assault as a false positive

### DIFF
--- a/falsepositives.go
+++ b/falsepositives.go
@@ -4,6 +4,7 @@ package goaway
 var DefaultFalsePositives = []string{
 	"analy", // analysis, analytics
 	"arsenal",
+	"assault",
 	"assassin",
 	"assaying", // was saying
 	"assert",

--- a/goaway_test.go
+++ b/goaway_test.go
@@ -448,7 +448,7 @@ func TestSentencesWithSneakyBadWords(t *testing.T) {
 }
 
 func TestNormalWords(t *testing.T) {
-	words := []string{"hello", "world", "whats", "up"}
+	words := []string{"hello", "world", "whats", "up", "assault"}
 	tests := []struct {
 		name              string
 		profanityDetector *ProfanityDetector


### PR DESCRIPTION
Fixes #142

Adds `assault` to the default false-positive list and covers it in the normal-words test so the reported game-mode name is not flagged.

Checks:
- `go test ./...`